### PR TITLE
Flesh out README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # modality-gazebo
 
+A [Gazebo](https://gazebosim.org/home) plugin to make it easy to send data to Modality from your simulator.
+
+For more information about Modality see the [documentation.](https://docs.auxon.io/modality/)
+
 ## Example
 
 1. Install dependencies.
@@ -18,3 +22,12 @@
   ```bash
   make run-example
   ```
+
+## Configuration
+
+The ModalityTracingPlugin accepts the following configuration:
+
+- `auth_token`: Auth token hex value. For more information on Modality auth tokens see the [documentation.](https://docs.auxon.io/modality/reference/cli/user.html#modality-user-mint-auth-token)
+- `timeline_name`: Name of the [timeline](https://docs.auxon.io/modality/concepts.html#events-and-timelines) for events produced by this plugin.
+- `allow_insecure_tls`: Whether to allow insecure TLS connections. Equivalent to the `allow-insecure-tls` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)
+- `modalityd_url`: URL of the modalityd daemon to send data to. Equivalent to the `protocol-parent-url` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Gazebo](https://gazebosim.org/home) plugin to make it easy to send data to Modality from your simulator.
 
+This plugin enables tracing of entities within a gazebo simulator world. You can enable it by adding the plugin and configuration to an SDF world file, like in the [example](examples/world.sdf#L92-#L105).
+
+The plugin provides tracing for an individual link, which will be assigned a timeline in Modality. Events are logged onto the timeline at every time step, unless the parent model is static, in which case a single event of each kind is logged.
+
 For more information about Modality see the [documentation.](https://docs.auxon.io/modality/)
 
 ## Example
@@ -25,9 +29,17 @@ For more information about Modality see the [documentation.](https://docs.auxon.
 
 ## Configuration
 
-The ModalityTracingPlugin accepts the following configuration:
+The ModalityTracingPlugin accepts the following general configuration:
 
-- `auth_token`: Auth token hex value. For more information on Modality auth tokens see the [documentation.](https://docs.auxon.io/modality/reference/cli/user.html#modality-user-mint-auth-token)
-- `timeline_name`: Name of the [timeline](https://docs.auxon.io/modality/concepts.html#events-and-timelines) for events produced by this plugin.
-- `allow_insecure_tls`: Whether to allow insecure TLS connections. Equivalent to the `allow-insecure-tls` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)
-- `modalityd_url`: URL of the modalityd daemon to send data to. Equivalent to the `protocol-parent-url` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)
+- `<link_name>chassis</link_name>`: Name of the link to be traced.
+- `<timeline_name>robot-chassis</timeline_name>`: Name of the [timeline](https://docs.auxon.io/modality/concepts.html#events-and-timelines) for events produced by this plugin.
+- `<auth_token>AUTH_TOKEN_HEX</auth_token>`: Auth token hex value. For more information on Modality auth tokens see the [documentation.](https://docs.auxon.io/modality/reference/cli/user.html#modality-user-mint-auth-token) Can alternatively be provided with the `MODALITY_AUTH_TOKEN` environment variable.
+- `<allow_insecure_tls>true</allow_insecure_tls>`: Whether to allow insecure TLS connections. Equivalent to the `allow-insecure-tls` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)
+- `<modalityd_url>modality-ingest://localhost:14182</modality_url>`: URL of the modalityd daemon to send data to. Equivalent to the `protocol-parent-url` option of the [`modality-reflector` config file.](https://docs.auxon.io/modality/ingest/modality-reflector-configuration-file.html)
+
+In addition, the following options configure which events the plugin should produce:
+
+- `<pose>true</pose>`: Log pose events with x, y, z, roll, pitch, yaw attributes.
+- `<linear_acceleration>true</linear_acceleration>`: Log linear acceleration events with x, y, z attributes.
+- `<linear_velocity>true</linear_velocity>`: Log velocity events with x, y, z attributes.
+- `<contact_collision>true</contact_collision>`: Log contact collision events with entity and name attributes.


### PR DESCRIPTION
@jonlamb-gh I'm working on a pass updating/standardizing/user-friendlying our OSS READMEs. I took a crack at this but it could really use a bit more explanation, in particular:
- What exactly does this do? What events does it report? Seems like it creates a single timeline? Can you have multiple in a single gazebo simulator? Can you configure what events it reports? Do you have to manually send events?
- Is referring to the entity as ModalityTracingPlugin correct?
- I saw all these inside the ModalityTracingPlugin:
```
<link_name>chassis</link_name>
<pose>true</pose>
<linear_acceleration>true</linear_acceleration>
<linear_velocity>true</linear_velocity>
<contact_collision>true</contact_collision>
```
Are these config options? Does this plugin just report standard simulator world data, and you're toggling what should be included in the events? Are there any other config options?